### PR TITLE
Fix linking and compilation on clear without libvdpau-dev installed

### DIFF
--- a/scripts/120-build-vdpauinfo
+++ b/scripts/120-build-vdpauinfo
@@ -20,7 +20,7 @@ fi
 
 if [[ -d ${name} ]]; then
     cd ${name}
-    ./autogen.sh --prefix=/usr/local && \
+    PKG_CONFIG_PATH=/usr/local/lib/pkgconfig ./autogen.sh --prefix=/usr/local && \
     make && make install
 fi
 

--- a/scripts/130-build-vdpau-driver
+++ b/scripts/130-build-vdpau-driver
@@ -25,7 +25,7 @@ if [[ -d ${name} ]]; then
         patch -p1 < "../../../patches/${name}/${file}"
         [[ $? -ne 0 ]] && exit $?
     done
-    ./autogen.sh --prefix=/usr --enable-glx && \
+    LDFLAGS="-L/usr/local/lib" CPPFLAGS="-I/usr/local/include" ./autogen.sh --prefix=/usr --enable-glx && \
     make -j 4 && make install && \
     rm -f /usr/lib64/dri/vdpau_drv_video.la
 fi


### PR DESCRIPTION
The build scripts seems to use libvdpau-dev included with many bundles by default (such as desktop-dev). On a brand new clear install, the compilation fails at script 130-*. This addition fixes that issue and makes sure that the self-compiled libvdpau.so library is used.