### PR TITLE
Remove non-required flag in 130-build-vdpau-driver

### DIFF
--- a/scripts/130-build-vdpau-driver
+++ b/scripts/130-build-vdpau-driver
@@ -25,7 +25,7 @@ if [[ -d ${name} ]]; then
         patch -p1 < "../../../patches/${name}/${file}"
         [[ $? -ne 0 ]] && exit $?
     done
-    LDFLAGS="-L/usr/local/lib" CPPFLAGS="-I/usr/local/include" ./autogen.sh --prefix=/usr --enable-glx && \
+    LDFLAGS="-L/usr/local/lib" ./autogen.sh --prefix=/usr --enable-glx && \
     make -j 4 && make install && \
     rm -f /usr/lib64/dri/vdpau_drv_video.la
 fi


### PR DESCRIPTION
The compilation process does not require a CPPFLAGS for the headers