### PR TITLE
Fix libvmaf.h not found when compiled from source

### DIFF
--- a/scripts/380-build-aom
+++ b/scripts/380-build-aom
@@ -25,6 +25,7 @@ if [[ -d ${name} ]]; then
     mkdir -p ${name}_build && cd ${name}_build
     export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig
     export LD_LIBRARY_PATH=/usr/local/lib
+    export CFLAGS=-I/usr/local/include/libvmaf $CFLAGS
     cmake -G Ninja \
         -DCMAKE_INSTALL_PREFIX=/usr/local \
         -DCMAKE_INSTALL_LIBDIR=lib \


### PR DESCRIPTION
Aom will fail to find libvmaf.h if it does not come from swupd. Point to the header compiled from source in all cases.